### PR TITLE
Chscratch

### DIFF
--- a/index.md
+++ b/index.md
@@ -194,6 +194,8 @@ In Scratch zou dit er ongeveer als volgt hebben uitgezien:
       als &lt;toets [pijltje rechts v] ingedrukt?&gt; dan
 	  verander x met (1)
       end
+	  end
+	  end
 {{< /scratch >}}
 
 Als je de code hebt ingevoerd (in Löve2D, niet in Scratch 😀), kun je het programma starten om uit te proberen of het werkt.
@@ -464,6 +466,7 @@ Voeg daarvoor de volgende code toe aan functie `love.update(dt)`:
 {{< scratch >}}
 	  als &lt;raak ik [Vijand v]?&gt; dan
 	  maak[spelIsAfgelopen v] (1)
+	  end
 {{< /scratch >}}
 
 {{< highlight lua >}}

--- a/index.md
+++ b/index.md
@@ -11,7 +11,8 @@ We gaan met 2D game "framework" Löve2D een shooter bouwen.
 
 <!--more-->
 
-We gaan een eenvoudige shooter maken. Deze instructie is een vertaling en bewerking van een [tutorial](http://osmstudios.com/tutorials/your-first-love2d-game-in-200-lines-part-1-of-3) gemaakt door >_OSMSTUDIOS.
+We gaan een eenvoudige shooter maken. 
+Deze instructie is een vertaling en bewerking van een [tutorial](http://osmstudios.com/tutorials/your-first-love2d-game-in-200-lines-part-1-of-3) gemaakt door >_OSMSTUDIOS.
 
 ## Wat leer je?
 Tijdens de Dojo's over Scratch hebben jullie kennis gemaakt met variabelen en functies (blokken). Daar gaan we mee verder.
@@ -19,8 +20,13 @@ Tijdens de Dojo's over Scratch hebben jullie kennis gemaakt met variabelen en fu
 In Scratch kun je met drag-and-drop variabelen en functies combineren tot een programma, maar bij de meeste 
 programmeertalen wordt het programma in tekst geschreven. Dat is ook het geval bij Löve. We gaan dus typen.
 
-Om het geen type sessie te laten zijn, zijn een aantal functies, net als bij Scratch, al voor jullie gemaakt. 
-Je hoeft ze dus niet helemaal zelf meer te maken. Je hoeft ze alleen maar te gebruiken.
+Omdat we er geen typecursus van willen maken, zijn een aantal functies, net als bij Scratch, al voor jullie gemaakt. 
+Je hoeft deze dus niet helemaal zelf meer te maken. Je hoeft ze alleen maar te gebruiken.
+Dit zijn de functies:
+`xRechterRand`, `yOnderRand`, `xWillekeurig`, `tekenVijanden`, `tekenKogels`, `maakNieuweVijand`, 
+`maakNieuweKogel`, `spelerHeeftVijandGeraakt` en `kogelHeeftVijandGeraakt`.
+<!-- Notitie: isGeraakt is puur een helper functie -->
+Als je deze in de uitleg tegenkomt, hoef je ze dus niet zelf te implementeren!
 
 ## Benodigdheden
 Om deze instructie te kunnen volgen, moet je Löve en een goede editor geïnstalleerd hebben. 
@@ -65,29 +71,27 @@ Typ dan cd `c:\games\shooter` om naar de folder te gaan waar je de code hebt nee
  om het programma te starten. Als alles goed gaat, krijg je een zwart venster.
 
 ### Stap 1: teken het vliegtuig van de speler
-In deze stap doen we het volgende:
-
-We laden het plaatje van het vliegtuig van de speler
-Tekenen het plaatje op het scherm
+In deze stap laden we het plaatje van het vliegtuig van de speler
+en tekenen we het plaatje op het scherm. 
 Open `main.lua` in je tekst editor en type het volgende:
 
 {{< highlight lua >}}
-	-- variabele om het plaatje in op te slaan
-	spelersVliegtuig = nil
-	
-	function love.load(arg)
-	  -- laadt het plaatje in de variabele
-	  spelersVliegtuig = love.graphics.newImage('plaatjes/spelersVliegtuig.png')
-	end
+-- variabele om het plaatje in op te slaan
+spelersVliegtuig = nil
+
+function love.load(arg)
+  -- laad het plaatje in de variabele
+  spelersVliegtuig = love.graphics.newImage('plaatjes/spelersVliegtuig.png')
+end
 {{< /highlight >}}
 
 En vervolgens om op het scherm te tekenen:
 
 {{< highlight lua >}}
-	function love.draw(dt)
-	  -- teken het plaatje op het scherm
-	  love.graphics.draw(spelersVliegtuig, 100, 100)
-	end
+function love.draw(dt)
+  -- teken het plaatje op het scherm
+  love.graphics.draw(spelersVliegtuig, 100, 100)
+end
 {{< /highlight >}}
 	
 Start je programmaatje en zie het resultaat:
@@ -99,48 +103,51 @@ Start je programmaatje en zie het resultaat:
 
 ![assen stelsel in Löve2D](images/image6.png)
 
-In de code hebben we bij het aanroepen van functie `love.graphics.draw` twee keer het getal 100 gebruikt. Deze worden 
-gebruikt om de positie van het plaatje in het scherm te bepalen. Daarbij is positie 0,0 links bovenin. Bij 100,100 is 
-het plaatje dus 100 stappen naar beneden en 100 naar rechts verschoven ten opzichte van 0,0.
-Voor de horizontale positie wordt vaak variabele naam x gebruikt en voor de verticale positie y.
+In de code hebben we bij het aanroepen van functie `love.graphics.draw` twee keer het getal `100` gebruikt. 
+Dit getal gebruiken we om de positie van het plaatje in het scherm te bepalen. Daarbij is positie `(0,0)` links bovenin. Bij `(100,100)` is 
+het plaatje dus 100 stappen naar beneden en 100 naar rechts verschoven ten opzichte van `(0,0)`.
+Voor de horizontale positie wordt vaak variabele naam `x` gebruikt en voor de verticale positie `y`.
+Een handige manier van opschrijven is `(x, y)`, bijvoorbeeld `(50, 30)` als `x = 50` en `y = 30`.
 
-In Scratch komen x en y waarden voor de plaats van een Sprite ook terug. Hieronder staat Scratch op x = 31 en y = -36
+In Scratch komen `x` en `y` waarden voor de plaats van een Sprite ook terug. 
+Hieronder staat Scratch op `x = 31` en `y = -36`
 
 ![x en y in Scratch](images/image8.png)
 
 {{< /verdieping >}}
 
 ### Stap 2: eigenschappen van de speler
-Het vliegtuig van de speler staat nu nog stil op positie 100,100, maar zal natuurlijk van links naar rechts gaan bewegen 
+Het vliegtuig van de speler staat nu nog stil op positie `(100,100)`, maar zal natuurlijk van links naar rechts gaan bewegen 
 als we wat verder zijn. Je zou kunnen zeggen dat de speler een aantal eigenschappen heeft:
 
 - het plaatje
 - de positie
 
 Om die informatie bij elkaar te houden, vervangen we variabele `spelersVliegtuig` door een nieuwe variabele waarin 
-meerdere eigenschappen opgeslagen kunnen worden:
+meerdere eigenschappen opgeslagen kunnen worden. Deze variabele noemen we `speler`:
 
 {{< highlight lua >}}
-	-- variabele om eigenschappen van de speler in op te slaan
-	speler = { x = 200, y = 560, plaatje = nil }
-	
-	function love.load(arg)
-	  -- laadt het plaatje in eigenschap plaatje van de variabele speler
-	  speler.plaatje = love.graphics.newImage('plaatjes/spelersVliegtuig.png')
-	end
+-- variabele om eigenschappen van de speler in op te slaan
+speler = { x = 200, y = 560, plaatje = nil }
+
+function love.load(arg)
+  -- laad het plaatje in eigenschap plaatje van de variabele speler
+  speler.plaatje = love.graphics.newImage('plaatjes/spelersVliegtuig.png')
+end
 {{< /highlight >}}
 	
-Het tekenen van het plaatje moet ook aangepast worden, zodat de nieuwe variabele met spelers eigenschappen gebruikt worden:
+Het tekenen van het plaatje moet ook aangepast worden, 
+zodat we de eigenschappen van de nieuwe variabele `speler` gebruiken:
 
 {{< highlight lua >}}
-	function love.draw(dt)
-	  -- teken het plaatje op het scherm
-	  love.graphics.draw(speler.plaatje, speler.x, speler.y)
-	end
+function love.draw(dt)
+  -- teken het plaatje op het scherm
+  love.graphics.draw(speler.plaatje, speler.x, speler.y)
+end
 {{< /highlight >}}
 	
-Start opnieuw je programma en zie dat het vliegtuig nu onder in het venster staat. De wijzigingen die je hebt gemaakt 
-zijn een voorbereiding om plaatje te kunnen laten bewegen.
+Start het programma opnieuw op, en je zal zien dat het vliegtuig nu onderin het venster staat. 
+De wijzigingen die je hebt gemaakt zorgen dat we het plaatje later kunnen laten bewegen.
 
 
 ### Stap 3: de speler bewegen
@@ -148,109 +155,142 @@ Je programma toont nu alleen een stilstaand plaatje. Dat is natuurlijk niet erg 
 
 
 #### Bewegen met pijltjes
-Om het plaatje te horizontaal te laten bewegen, moet de `speler.x` eigenschap worden aangepast. De waarde van `speler.x`
+Om het plaatje horizontaal te laten bewegen, moet de `speler.x` eigenschap worden aangepast. De waarde van `speler.x`
  moet kleiner worden om naar links te bewegen en groter om naar rechts te bewegen. Je kunt dit ook eenvoudig uitproberen 
- door de waarde 200 in de code groter of kleiner te maken en je programma te starten.
+ door de waarde `200` in de code groter of kleiner te maken en je programma te starten.
 
 Om het plaatje te laten bewegen terwijl het programma draait, moet het programma gaan reageren op toetsen van je 
-toetsenbord. De pijl naar links zorgt voor een beweging naar links en de pijl naar rechts voor een beweging naar rechts:
-
-![Scratch voorbeeld pijl links en rechts](images/image16.png)
+toetsenbord. De pijl naar links zorgt voor een beweging naar links en de pijl naar rechts zorgt voor een beweging naar rechts:
 
 {{< highlight lua >}}
-	function love.update(dt)
-	  -- als pijltje naar links wordt ingedrukt
-	  if love.keyboard.isDown('left') then
-	
-	    -- dan doe een stap naar links
-	    speler.x = speler.x - 1
-	
-	  -- als pijltje naar rechts wordt ingedrukt
-	  elseif love.keyboard.isDown('right') then
-	
-	    -- dan doe een stap naar rechts
-	    speler.x = speler.x + 1
-	  end
-	end
+function love.update(dt)
+  -- als pijltje naar links wordt ingedrukt
+  if love.keyboard.isDown('left') then
+
+	-- dan doe een stap naar links
+	speler.x = speler.x - 1
+
+  -- als pijltje naar rechts wordt ingedrukt
+  elseif love.keyboard.isDown('right') then
+
+	-- dan doe een stap naar rechts
+	speler.x = speler.x + 1
+  end
+end
 {{< /highlight >}}
 	
-Als je voor het eerst naar programmeercode kijkt ziet het bovenstaande er ingewikkeld uit, maar vergelijk het eens met 
-het bewegen met pijltjes in Scratch. `love.update(dt)` wordt steeds opnieuw uitgevoerd en is daarom vergelijkbaar met 
-de 'herhaal' in Scratch en 'if ... then' is gelijk aan 'als ... dan' in Scratch.
+Als je voor het eerst dit soort code leest ziet het bovenstaande voorbeeld er ingewikkeld uit.
+Maar: vergelijk het eens met het bewegen via pijltjes in Scratch. `love.update(dt)` wordt steeds opnieuw uitgevoerd en is daarom vergelijkbaar met 
+de `herhaal` loop in Scratch. `if ... then` is gelijk aan de `als ... dan` keuze in Scratch.
+In Scratch zou dit er ongeveer als volgt hebben uitgezien:
 
-Als je de programmeercode hebt ingevoerd, kun je het programma starten om uit te proberen of het werkt.
+<!--![Scratch voorbeeld pijl links en rechts](images/image16.png)-->
 
-Probeer ook eens een andere stapgrootte dan 1. Doet dat wat je ervan verwacht? Wat gebeurt er als je er een negatief getal van maakt?
-Kun je de code aanpassen, zodat je ook naar boven en beneden kunt bewegen (gebruik toetsen 'up' voor naar boven en 'down' voor naar beneden)?
+{{< scratch >}}
+      wanneer groene vlag wordt aangeklikt
+      herhaal
+      als &lt;toets [pijltje links v] ingedrukt?&gt; dan
+	  verander x met (-1)
+      als &lt;toets [pijltje rechts v] ingedrukt?&gt; dan
+	  verander x met (1)
+      end
+{{< /scratch >}}
+
+Als je de code hebt ingevoerd (in Löve2D, niet in Scratch 😀), kun je het programma starten om uit te proberen of het werkt.
+
+Probeer ook eens een andere stapgrootte dan `1`. Doet dat wat je ervan verwacht? Wat gebeurt er als je er een negatief getal van maakt?
+Kun je de code aanpassen, zodat je ook naar boven en beneden kunt bewegen 
+(gebruik toetsen `up` voor naar boven en `down` voor naar beneden)?
 Wat gebeurt er als je bijvoorbeeld het pijltje naar rechts lang ingedrukt houdt?
 
 
 #### Stoppen bij de rand
-Om te voorkomen dat het plaatje onzichtbaar wordt, moeten we voorkomen dat het verder beweegt als het aan de randen 
-van het venster komt. Aan de linker kant is dat makkelijk: beweeg niet verder als `speler.x` gelijk is aan 0. 
+Om te voorkomen dat het plaatje het venster kan verlaten, 
+moeten we voorkomen dat het verder beweegt als het aan de randen 
+van het venster komt. Aan de linker kant is dat makkelijk: 
+beweeg niet verder als `speler.x` gelijk is aan `0`. 
 In code ziet dat er als volgt uit:
 
 {{< highlight lua >}}
-	-- als pijltje naar links ingedrukt
-	if love.keyboard.isDown('left') then
-	
-	  -- en linker rand is nog niet bereikt
-	  if speler.x > 0 then
-	
-	    -- dan doe een stap naar links
-	    speler.x = speler.x - 1
-	
-	  end
+-- als pijltje naar links ingedrukt
+if love.keyboard.isDown('left') then
+
+  -- en linker rand is nog niet bereikt
+  if speler.x > 0 then
+
+	-- dan doe een stap naar links
+	speler.x = speler.x - 1
+
+  end
 {{< /highlight >}}
     
-Aan de rechter zijde is dat lastiger. Daar hangt de maximale 'x' af van de breedte van het venster. De maximale waarde 
-voor x is gelijk aan de breedte van het venster, of `xRechterRand()`:
+Aan de rechter zijde is dat lastiger. 
+Daar hangt de maximale `x` af van de breedte van het venster. De maximale waarde 
+voor `x` is gelijk aan de breedte van het venster, of `xRechterRand()`.
+Let op: `xRechterRand` is een van de kant en klare functies!
 
 {{< highlight lua >}}
-	-- als pijltje naar rechts ingedrukt
-	elseif love.keyboard.isDown('right') then
-	
-	  -- en de rechter rand is nog niet bereikt
-	  if speler.x < xRechterRand() then
-	
-	    -- dan doe een stap naar rechts
-	    speler.x = speler.x + 1
-	
-	  end
-	end
+-- als pijltje naar rechts ingedrukt
+elseif love.keyboard.isDown('right') then
+
+  -- en de rechter rand is nog niet bereikt
+  if speler.x < xRechterRand() then
+
+	-- dan doe een stap naar rechts
+	speler.x = speler.x + 1
+
+  end
+end
 {{< /highlight >}}
 	
 Pas de code die je eerder bij stap 3 (bewegen met pijltjes) hebt geschreven aan, zodat je stopt bij de rand. Controleer 
 ook of het plaatje nu niet aan de rechterkant verdwijnt. Voor de duidelijkheid hebben we de Scratch code ook 
-aangepast en bijgevoegd (zie plaatje rechts).
+aangepast en bijgevoegd:
 
-![Scratch voorbeeld maximaal rechts](images/image14.png)
+<!--![Scratch voorbeeld maximaal rechts](images/image14.png)-->
+
+{{< scratch >}}
+      wanneer groene vlag wordt aangeklikt
+      herhaal
+      als &lt;toets [pijltje links v] ingedrukt?&gt; dan
+	  als &lt;(x-positie) > (0)&gt; dan
+	  verander x met (-1)
+	  end
+	  end
+      als &lt;toets [pijltje rechts v] ingedrukt?&gt; dan
+	  als &lt;(x-positie) < (240)&gt; dan
+	  verander x met (1)
+	  end
+	  end
+      end
+{{< /scratch >}}
 
 ### Stap 4: de vijand
 Het spel draait natuurlijk niet alleen om het heen en weer bewegen van een vliegtuigje. 
-Er is ook een vijand. In deze stap gaan we vijanden maken.
+Er zijn ook vijanden. In deze stap gaan we die vijanden maken.
 
-We beginnen met het tekenen van één vijand. Daarvoor voegen we één regel toe (bijna bovenaan je code) en we voegen 
+We beginnen met het tekenen van één vijand. 
+Daarvoor voegen we één regel toe (bijna bovenaan je code) en we voegen 
 een regel code toe aan de `love.load()` en `love.draw()` functies:
 
 {{< highlight lua >}}
-	-- variabelen om eigenschappen van de speler en vijand in op te slaan
-	speler = { x = 200, y = 560, plaatje = nil }
-	vijand = { x = 200, y = 0, plaatje = nil }
-	
-	function love.load(arg)
+-- variabelen om eigenschappen van de speler en vijand in op te slaan
+speler = { x = 200, y = 560, plaatje = nil }
+vijand = { x = 200, y = 0, plaatje = nil }
 
-	  -- laadt het plaatje in eigenschap plaatje van de variabele speler
-	  speler.plaatje = love.graphics.newImage('plaatjes/spelersVliegtuig.png')
-	  vijand.plaatje = love.graphics.newImage('plaatjes/vijandsVliegtuig.png')
-	end
-	
-	function love.draw(dt)
+function love.load(arg)
 
-	  -- teken het plaatje op het scherm
-	  love.graphics.draw(speler.plaatje, speler.x, speler.y)
-	  love.graphics.draw(vijand.plaatje, vijand.x, vijand.y)
-	end
+  -- laad het plaatje in eigenschap plaatje van de variabele speler
+  speler.plaatje = love.graphics.newImage('plaatjes/spelersVliegtuig.png')
+  vijand.plaatje = love.graphics.newImage('plaatjes/vijandsVliegtuig.png')
+end
+
+function love.draw(dt)
+
+  -- teken het plaatje op het scherm
+  love.graphics.draw(speler.plaatje, speler.x, speler.y)
+  love.graphics.draw(vijand.plaatje, vijand.x, vijand.y)
+end
 {{< /highlight >}}
 			
 Probeer bovenstaande code uit.
@@ -259,21 +299,24 @@ Er is nu één vijand en deze staat recht tegenover de speler. Een stilstaande v
 'm naar de speler bewegen. Dat kan vrij eenvoudig door het volgende aan de code toe te voegen aan je `love.update(dt)` functie:
 
 {{< highlight lua >}}
-	function love.update(dt)
+function love.update(dt)
 
-	  -- laat de vijand een stapje naar beneden doen 
-	  vijand.y = vijand.y + 1
+  -- laat de vijand een stapje naar beneden doen 
+  vijand.y = vijand.y + 1
 {{< /highlight >}}
 			
-Bovenstaande code werkt hetzelfde als het verplaatsen van de speler. Nu bewegen we alleen wel verticaal (van boven naar 
-beneden). Daardoor moeten we y in plaats van x veranderen. De positie van de vijand wordt steeds met 1 stapje naar 
+Bovenstaande code werkt hetzelfde als het verplaatsen van de speler. 
+Nu bewegen we echter verticaal, van boven naar beneden. 
+Daarom moeten we de `y`-positie in plaats van de `x`-positie veranderen. 
+De positie van de vijand wordt steeds met `1` stapje naar 
 beneden verzet. Zo beweegt de vijand naar de speler toe.
 
-Om het plaatje van buiten het venster tevoorschijn te laten komen, moet de y positie aangepast worden naar -100. 
-Pas de code bovenin je script aan door y = 0 te veranderen naar y = -100:
+Om het plaatje van buiten het venster tevoorschijn te laten komen, 
+moet de `y`-positie aangepast worden naar `-100`. 
+Pas de code bovenin je script aan door `y = 0` te veranderen naar `y = -100`:
 
 {{< highlight lua >}}
-	vijand = { x = 200, y = -100, plaatje = nil }
+vijand = { x = 200, y = -100, plaatje = nil }
 {{< /highlight >}}
 			
 Onder aan het scherm vliegt de vijand het venster uit en is dan verdwenen. Het is natuurlijk leuker als er aan de 
@@ -281,114 +324,130 @@ bovenkant een nieuwe vijand verschijnt. Daarvoor moet je, net als bij het bewege
 onderstaande code toevoegen aan `love.update(dt)`:
 
 {{< highlight lua >}}
-	-- als de vijand de onderrand heeft bereikt
-	if vijand.y > yOnderRand() then
-	
-	  -- verplaats het dan uit het zicht boven het venster
-	  vijand.y = -100
-	
-	end
+-- als de vijand de onderrand heeft bereikt
+if vijand.y > yOnderRand() then
+
+  -- verplaats het dan uit het zicht boven het venster
+  vijand.y = -100
+
+end
 {{< /highlight >}}
 			
 Om je te helpen met het begrijpen van de code: het verplaatsen van de vijand in Scratch zou er ongeveer zo uitzien:
 
-![Scratch verplaatsen vijand](images/image18.png)
+<!--![Scratch verplaatsen vijand](images/image18.png)-->
+
+{{< scratch >}}
+	  verander y met (1)
+	  als &lt;(y-positie) > (180)&gt; dan
+	  maak y (-200)
+	  end
+{{< /scratch >}}
 
 Om het nog interessanter te maken, zou het leuk zijn als de vijand niet steeds op dezelfde plaats van boven naar 
 beneden beweegt. De waarde van `vijand.x` (horizontale positie) zou iedere keer anders moeten zijn. 
 Gebruik daarvoor de functie `xWillekeurig()`:
 
 {{< highlight lua >}}
-	-- als de vijand de onderrand heeft bereikt
-	if vijand.y > yOnderRand() then
-	
-	  -- verplaats het dan uit het zicht boven het venster
-	  vijand.y = -100
-	
-	  -- en zet de horizontale positie naar een willekeurige waarde
-	  vijand.x = xWillekeurig()
-	
-	end
+-- als de vijand de onderrand heeft bereikt
+if vijand.y > yOnderRand() then
+
+  -- verplaats het dan uit het zicht boven het venster
+  vijand.y = -100
+
+  -- en zet de horizontale positie naar een willekeurige waarde
+  vijand.x = xWillekeurig()
+
+end
 {{< /highlight >}}
 			
-Wat je in Scratch zo zou doen:
+Wat je in Scratch zou doen:
 
-![Scratch random start positie vijand](images/image13.png)
+<!--![Scratch random start positie vijand](images/image13.png)-->
+
+{{< scratch >}}
+	  verander y met (1)
+	  als &lt;(y-positie) > (180)&gt; dan
+	  maak y (-200)
+	  maak x (willekeurig getal tussen (-240) en (240))
+	  end
+{{< /scratch >}}
 
 ### Stap 5: meerdere vijanden
-We hebben nu een enkele vijand. Die is natuurlijk makkelijk te ontwijken. Spannender wordt het, als we er meerdere hebben. 
+We hebben nu een enkele vijand. Die is natuurlijk makkelijk te ontwijken. 
+Het wordt veel spannender met meerdere vijanden.
 Daarvoor moeten we het één en ander aanpassen, de code die je eerder hebt geschreven voor één vijand, gaan we vervangen 
 met code voor meerdere vijanden. Je moet hier en daar dus code verwijderen!
 
-Allereerst hebben we een lijst met vijanden nodig, die voegen we bovenaan de code toe, bij 'speler'. 
+Allereerst hebben we een lijst met vijanden nodig, die voegen we bovenaan de code toe, bij `speler`. 
 Variabelen staan vaak bovenaan in code:
 
 {{< highlight lua >}}
-	-- variabelen om eigenschappen van de speler in op te slaan
-	speler = { x = 200, y = 560, plaatje = nil }
-	
-	-- lijst om vijanden in op te slaan
-	vijanden = {}
+-- variabelen om eigenschappen van de speler in op te slaan
+speler = { x = 200, y = 560, plaatje = nil }
+
+-- lijst om vijanden in op te slaan
+vijanden = {}
 {{< /highlight >}}
 			
 Een andere variabele die we nodig hebben is het plaatje van de vijand. Eerder deden we dat in de functie `love.draw(dt)`
  met `speler.plaatje`. Die regel mag nu verwijderd worden en in plaats daarvan zetten we bij de variabelen 
- 'speler' en 'vijanden' ook het plaatje voor de vijand:
+ `speler` en `vijanden` ook het plaatje voor de vijand:
 
 {{< highlight lua >}}
-	-- laad het plaatje van de vijand
-	vijandPlaatje = love.graphics.newImage('plaatjes/vijandsVliegtuig.png')
+-- laad het plaatje van de vijand
+vijandPlaatje = love.graphics.newImage('plaatjes/vijandsVliegtuig.png')
 {{< /highlight >}}
 			
 De vijanden moeten ook getekend worden, zorg ervoor dat jouw `love.draw(dt)` functie eruit ziet zoals hieronder:
 
 {{< highlight lua >}}
-	function love.draw(dt)
-	
-	  -- teken het plaatje op het scherm
-	  love.graphics.draw(speler.plaatje, speler.x, speler.y)
-	
-	  -- teken de vijanden in de lijst
-	  tekenVijanden(vijanden)
-	
-	end
+function love.draw(dt)
+
+  -- teken het plaatje op het scherm
+  love.graphics.draw(speler.plaatje, speler.x, speler.y)
+
+  -- teken de vijanden in de lijst
+  tekenVijanden(vijanden)
+
+end
 {{< /highlight >}}
 			
 Er worden alleen vijanden getekend die bestaan, daarom moeten vijanden ook aangemaakt worden:
 
 {{< highlight lua >}}
-	function love.update(dt)
-	
-	  maakNieuweVijand(vijanden)
+function love.update(dt)
+
+  maakNieuweVijand(vijanden)
 {{< /highlight >}}
 			
 In de vorige stap hebben we de vijand laten bewegen. Deze code moeten we nu voor iedere vijand in de lijst uitvoeren:
 
 {{< highlight lua >}}
-	function love.update(dt)
-	
-	  maakNieuweVijand(vijanden) 
-	
-	  -- voor elke vijand in de lijst  
-	  for index, vijand in ipairs(vijanden) do
-	
-	    -- laat de vijand een stapje naar beneden doen  
-	    vijand.y = vijand.y + 2
-	
-	    -- als de vijand de onderrand heeft bereikt
-	    if vijand.y > yOnderRand() then
-	
-	      -- verwijder de vijand
-	      table.remove(vijanden, index)
-	
-	    end
-	  end
+function love.update(dt)
+
+  maakNieuweVijand(vijanden) 
+
+  -- voor elke vijand in de lijst  
+  for index, vijand in ipairs(vijanden) do
+
+	-- laat de vijand een stapje naar beneden doen  
+	vijand.y = vijand.y + 2
+
+	-- als de vijand de onderrand heeft bereikt
+	if vijand.y > yOnderRand() then
+
+	  -- verwijder de vijand
+	  table.remove(vijanden, index)
+
+	end
+  end
 {{< /highlight >}}
 			
 Het maken en verwijderen van vijanden zoals we dat hierboven doen is in Scratch heel lastig. We geven daarom geen 
 voorbeeld van het bovenstaande in Scratch. Waar het kan doen we dat wel.
 
-Voer het programma uit. Als het goed is ziet het eruit als onderstaande plaatje:
+Voer het programma uit. Als het goed is ziet het eruit als in onderstaande plaatje:
 
 ![scherm met vijandelijke vliegtuigen](images/image3.png)
 
@@ -396,131 +455,143 @@ Voer het programma uit. Als het goed is ziet het eruit als onderstaande plaatje:
 Als de speler een vijand raakt, is het spel afgelopen. Om te zien of de speler een vijand geraakt heeft, hebben we 
 functie `spelerHeeftVijandGeraakt()`.
 
-Als het resultaat van de functie waar (true) is, dan moet het spel gestopt worden.
+Als het resultaat van de functie waar (`true`) is, dan moet het spel gestopt worden.
 
 Voeg daarvoor de volgende code toe aan functie `love.update(dt)`:
 
-![Scratch spel is afgelopen](images/image2.png)
+<!--![Scratch spel is afgelopen](images/image2.png)-->
+
+{{< scratch >}}
+	  als &lt;raak ik [Vijand v]?&gt; dan
+	  maak[spelIsAfgelopen v] (1)
+{{< /scratch >}}
 
 {{< highlight lua >}}
-	-- als de speler een vijand geraakt heeft
-	if spelerHeeftVijandGeraakt() then
-	
-	  -- is het spel afgelopen
-	  spelIsAfgelopen = true
-	
-	end
+-- als de speler een vijand geraakt heeft
+if spelerHeeftVijandGeraakt() then
+
+  -- is het spel afgelopen
+  spelIsAfgelopen = true
+
+end
 {{< /highlight >}}
 			
 In variabele `spelIsAfgelopen` wordt bijgehouden of het spel nog loopt of al is afgelopen. Als het is afgelopen, 
-wordt de speler niet langer getekend. Pas daarvoor functie `love.draw(dt)` aan door het tekenen van de speler 
-binnen een if statement te plaatsen:
+wordt de speler niet langer getekend. Pas daarvoor de functie `love.draw(dt)` aan door het tekenen van de speler 
+binnen een `if` statement te plaatsen:
 
 {{< highlight lua >}}
-	function love.draw(dt)
-	
-	  -- als het spel nog niet is afgelopen
-	  if spelIsAfgelopen == false then
-	
-	    -- teken het plaatje op het scherm
-	    love.graphics.draw(speler.plaatje, speler.x, speler.y)
-	
-	  end
+function love.draw(dt)
+
+  -- als het spel nog niet is afgelopen
+  if spelIsAfgelopen == false then
+
+	-- teken het plaatje op het scherm
+	love.graphics.draw(speler.plaatje, speler.x, speler.y)
+
+  end
 {{< /highlight >}}
 			
 In Scratch zou het er zo uitzien:
 
-![Scratch verschijn](images/image11.png)
+<!--![Scratch verschijn](images/image11.png)-->
+
+{{< scratch >}}
+	  als &lt;(spelIsAfgelopen) = (0)&gt; dan
+	  verschijn
+	  end
+{{< /scratch >}}
 
 Vergeet niet om bovenaan het bestand de variabele toe te voegen:
 
 {{< highlight lua >}}
-	spelIsAfgelopen = false
+spelIsAfgelopen = false
 {{< /highlight >}}
 			
 Als je nu het spel speelt, wordt het spelersvliegtuig niet meer getekend als je een vijand hebt geraakt.
 
 
 ### Stap 7: schieten
-De stap schieten lijkt op een combinatie van stappen 4 en 5..
+De stap schieten lijkt op een combinatie van stappen 4 en 5.
 
 Er moet een lijst worden toegevoegd voor de kogels:
 
 {{< highlight lua >}}
-	-- variabelen om eigenschappen van de speler in op te slaan
-	speler = { x = spelerX, y = spelerY, plaatje = nil }
-	
-	-- lijst om vijanden in op te slaan
-	vijanden = {}
-	
-	-- lijst om kogels in op te slaan
-	kogels = {}
+-- variabelen om eigenschappen van de speler in op te slaan
+speler = { x = spelerX, y = spelerY, plaatje = nil }
+
+-- lijst om vijanden in op te slaan
+vijanden = {}
+
+-- lijst om kogels in op te slaan
+kogels = {}
 {{< /highlight >}}
 			
 Het plaatje van de kogel moet worden geladen:
 
 {{< highlight lua >}}
-	-- laad het plaatje van de vijand
-	vijandPlaatje = love.graphics.newImage('plaatjes/vijandsVliegtuig.png')
-	
-	-- laad het plaatje van de kogel
-	kogelPlaatje = love.graphics.newImage('plaatjes/kogel.png')
+-- laad het plaatje van de vijand
+vijandPlaatje = love.graphics.newImage('plaatjes/vijandsVliegtuig.png')
+
+-- laad het plaatje van de kogel
+kogelPlaatje = love.graphics.newImage('plaatjes/kogel.png')
 {{< /highlight >}}
 			
 En het plaatje moet worden getekend, dat doe je in de `love.draw(dt)` functie:
 
 {{< highlight lua >}}
-	-- teken de kogels in de lijst
-	tekenKogels(kogels)
+-- teken de kogels in de lijst
+tekenKogels(kogels)
 {{< /highlight >}}
 			
 In tegenstelling tot de vijanden, worden nieuwe kogels alleen aangemaakt als de speler de spatiebalk indrukt. 
 In de `love.update(dt)` functie voeg je het volgende toe:
 
 {{< highlight lua >}}
-    if spelIsAfgelopen == false then
+if spelIsAfgelopen == false then
 
-	-- als de spatiebalk wordt ingedrukt
-	if love.keyboard.isDown('space') then
-	
-	  -- schiet dan
-	  maakNieuweKogel(kogels, speler)
+-- als de spatiebalk wordt ingedrukt
+if love.keyboard.isDown('space') then
 
-	end
+  -- schiet dan
+  maakNieuweKogel(kogels, speler)
 
-        maakNieuweVijand(vijanden)  
+end
+
+	maakNieuweVijand(vijanden)  
 {{< /highlight >}}
 			
-Als je de code tot nu toe uitprobeert, krijg je wel een kogels te zien, maar die bewegen niet, het ziet eruit als het plaatje hieronder.
+Als je de code tot nu toe uitprobeert, krijg je wel kogels te zien, maar die bewegen niet. 
+Dit ziet eruit als het plaatje hieronder.
 
 ![scherm met vijandelijke vliegtuigen en kogels](images/image12.png)
 
-Aan de `love.update(dt)` functie moet nog wat extra code worden toegevoegd om de kogels te laten bewegen. 
-Elke kogel in de lijst laten we telkens vier stappen omhoog gaan en als een kogel uit beeld verdwijnt, 
-halen we de kogel ook uit de lijst:
+Aan de `love.update(dt)` functie moet extra code worden toegevoegd om de kogels te laten bewegen. 
+Elke kogel in de lijst laten we telkens vier stappen omhoog gaan. 
+Als een kogel uit beeld verdwijnt, halen we de kogel ook uit de lijst:
 
 {{< highlight lua >}}
-    if spelIsAfgelopen == false then
-        -- als de spatiebalk wordt ingedrukt
-        if love.keyboard.isDown('space') then
-            -- schiet dan
-            maakNieuweKogel(kogels, speler)
-        end
+if spelIsAfgelopen == false then
+	-- als de spatiebalk wordt ingedrukt
+	if love.keyboard.isDown('space') then
+		-- schiet dan
+		maakNieuweKogel(kogels, speler)
+	end
 
-        -- voor elke kogel in de lijst
-        for index, kogel in ipairs(kogels) do
+	-- voor elke kogel in de lijst
+	for index, kogel in ipairs(kogels) do
 
-            -- beweeg de kogel naar boven
-            kogel.y = kogel.y - (2 * stapGrootte)
+		-- beweeg de kogel naar boven
+		kogel.y = kogel.y - (2 * stapGrootte)
 
-            -- als de kogel de bovenrand heeft bereikt
-            if kogel.y < -20 then
-                -- verwijder het uit de lijst
-                table.remove(kogels, index)
-            end
-        end
+		-- als de kogel de bovenrand heeft bereikt
+		if kogel.y < -20 then
+			-- verwijder het uit de lijst
+			table.remove(kogels, index)
+		end
+	end
 
-        maakNieuweVijand(vijanden)  
+	maakNieuweVijand(vijanden)  
 {{< /highlight >}}
 			
 Dat ziet er beter uit!
@@ -529,42 +600,50 @@ Dat ziet er beter uit!
 
 
 ### Stap 8: raken en scoren
-De vijanden vliegen, je kunt je vliegtuig richten en je kunt schieten. Maar je schoten raken nog niets en de 
+De vijanden vliegen, je kunt je vliegtuig besturen en je kan schieten. 
+Maar je schoten raken nog niets en de 
 vijanden vliegen door. Daar gaan we in deze stap wat aan doen.
 
 Functie `kogelHeeftVijandGeraakt()` laat ons weten of een kogel een vijand geraakt heeft. 
-Ook verwijderd deze functie de geraakte vijand en de kogel:
+Ook verwijdert deze functie de geraakte vijand en de kogel:
 
 {{< highlight lua >}}
-	-- als de kogel een vijand geraakt heeft
-	if kogelHeeftVijandGeraakt() then
-	
-	  -- heb je een punt gescoord
-	  score = score + 1
-	
-	end
+-- als de kogel een vijand geraakt heeft
+if kogelHeeftVijandGeraakt() then
+
+  -- heb je een punt gescoord
+  score = score + 1
+
+end
 {{< /highlight >}}
 			
 Voeg bovenstaande code toe aan `love.update(dt)`. Om de score in op te slaan, moet je ook nog een variabele 
 aanmaken boven aan het bestand:
 
 {{< highlight lua >}}
-	score = 0
+score = 0
 {{< /highlight >}}
 			
 In Scratch ziet het er zo uit:
 
-![Scratch werk score bij](images/image20.png)
+<!--![Scratch werk score bij](images/image20.png)-->
 
-We willen natuurlijk de score kunnen zien, dus moeten we die in het scherm afdrukken. 
+{{< scratch >}}
+	  maak [score v] (0)
+	  als &lt;raak ik [Kogel v]?&gt; dan
+	  verander [score v] met (1)
+	  end
+{{< /scratch >}}
+
+We willen natuurlijk de score kunnen zien.
 Voeg daarvoor in `love.draw(dt)` het volgende toe:
 
 {{< highlight lua >}}
-	-- zet de tekstkleur op wit
-	love.graphics.setColor(255, 255, 255)
-	
-	-- en druk de score af
-	love.graphics.print("SCORE: " .. tostring(score), 400, 10)
+-- zet de tekstkleur op wit
+love.graphics.setColor(255, 255, 255)
+
+-- en druk de score af
+love.graphics.print("SCORE: " .. tostring(score), 400, 10)
 {{< /highlight >}}
 			
 ### Stap 9: opnieuw starten
@@ -573,33 +652,33 @@ Mocht je een vijand aanraken, dan is het spel afgelopen, maar dan wil je natuurl
 Daarvoor gaan we code toevoegen aan `love.update(dt)`:
 
 {{< highlight lua >}}
-  -- als de o van opnieuw wordt ingedrukt
-  if love.keyboard.isDown('o') then
+-- als de o van opnieuw wordt ingedrukt
+if love.keyboard.isDown('o') then
 
-    -- wordt het spel opnieuw gestart
-    kogels = {}
-    vijanden = {}
-    score = 0
-    spelIsAfgelopen = false
+-- wordt het spel opnieuw gestart
+kogels = {}
+vijanden = {}
+score = 0
+spelIsAfgelopen = false
 
-  end
+end
 {{< /highlight >}}
 			
-Als je op 'o' drukt begint je spel opnieuw. Het spel is nu klaar!
+Als je op de toets `o` drukt begint je spel opnieuw. Het spel is nu klaar!
 
 
 ### Voorbereide functies
 Bij het maken van het spelletje heb je gebruik gemaakt van een aantal voorbereide functies. Als je je nu afvraagt hoe 
-die functies zijn gemaakt, dan kun je eens kijken in bestand [functies.lua](src/functies.lua).
+die functies zijn gemaakt, dan kun je eens kijken in het bestand [functies.lua](src/functies.lua).
 
 
 ### Voorbeeld code
-Mocht je nu ook nog een voorbeeld van de volledige code willen bekijken, dan moet je eens kijken in 
+Mocht je nu ook nog een voorbeeld van de volledige code willen bekijken, dan kan je eens kijken in 
 [voorbeeld.lua](src/voorbeeld.lua).
 
 
 ## Conclusie
-Het spelletje is af en je hebt geleerd hoe je vrij gemakkelijk een 2D shooter kunt maken met Löve.
+Het spelletje is af en je hebt geleerd hoe je een 2D shooter kunt maken met Löve.
 
 
 ## Vervolg

--- a/index.md
+++ b/index.md
@@ -48,7 +48,7 @@ Als je twijfelt tussen de 32- of 64-bits versie, kun je voor de zekerheid kiezen
 [checken](https://support.microsoft.com/nl-nl/help/13443/windows-which-operating-system) welke versie je hebt.
 
 #### Mac
-[Download](https://love2d.org/%23download) het zip bestand voor Mac en unzip het op de gewenste locatie.
+[Download](https://love2d.org/#download) het zip bestand voor Mac en unzip het op de gewenste locatie.
 
 #### Linux
 Voor Ubuntu kun je kiezen voor het toevoegen van de [Löve PPA](https://launchpad.net/~bartbes/%2Barchive/ubuntu/love-stable)
@@ -56,7 +56,7 @@ Voor Ubuntu kun je kiezen voor het toevoegen van de [Löve PPA](https://launchpa
 
 #### Tekst editor
 Als je gaat programmeren is het handig om een editor te installeren met meer mogelijkheden dan 'kladblok'.
-[Sublime Text](https://www.sublimetext.com/3) snapt Lua en dus Löve. Als alternatief kun je kiezen voor 
+[Sublime Text](https://www.sublimetext.com/download) snapt Lua en dus Löve. Als alternatief kun je kiezen voor 
 [Notepad++](https://notepad-plus-plus.org/download/).
 
 ## Stappen

--- a/index.md
+++ b/index.md
@@ -51,8 +51,35 @@ Als je twijfelt tussen de 32- of 64-bits versie, kun je voor de zekerheid kiezen
 [Download](https://love2d.org/#download) het zip bestand voor Mac en unzip het op de gewenste locatie.
 
 #### Linux
-Voor Ubuntu kun je kiezen voor het toevoegen van de [Löve PPA](https://launchpad.net/~bartbes/%2Barchive/ubuntu/love-stable)
- of voor de installatie van één van de .deb bestanden.
+Voor Ubuntu kun je kiezen voor het toevoegen van de 
+[Löve PPA](https://launchpad.net/~bartbes/%2Barchive/ubuntu/love-stable)
+of voor de installatie van één van de .deb bestanden.  
+Onderstaand vind je de instructies voor het gebruiken van de AppImage:
+
+{{< voorbeeld kop="Instructies voor het gebruiken van de Löve AppImage" md=true >}}
+1. Download de [Löve `appimage x86_64`](https://love2d.org/#download). 
+Zet deze bijvoorbeeld in je `~/Documents` directory.  
+
+2. Voer hier vervolgens de volgende commands op uit (vanuit `~/Documents`). 
+Je `.AppImage` kan een andere versie/naam hebben dan in het voorbeeld!
+{{< highlight verbatim >}}
+chmod u+x love-11.4-x86_64.AppImage
+./love-11.4-x86_64.AppImage --appimage-extract
+{{< /highlight >}}
+
+3. Het resultaat is een directory `~/Documents/squashfs-root`. 
+Deze directory bevat het bestand `AppRun`, welke uitvoerbaar is.
+4. Zorg nu dat je weet waar je `.lua` bestanden staan (zie onderstaande stap 1). 
+In ons voorbeeld is dit in `~/Documents/love2d-shooter-master/src/`. 
+Je voert de code dan op de volgende manier uit:
+{{< highlight verbatim >}}
+~/Documents/squashfs-root/AppRun ~/Documents/love2d-shooter-master/src/
+{{< /highlight >}}
+
+Let op dat het scherm in eerste instantie zwart is, omdat we nog geen code geschreven hebben.  
+Mocht het niet lukken om de code op deze manier uit te voeren, vraag dan gerust om hulp!
+{{< /voorbeeld >}}
+
 
 #### Tekst editor
 Als je gaat programmeren is het handig om een editor te installeren met meer mogelijkheden dan 'kladblok'.
@@ -65,8 +92,8 @@ TIP: de onderstaande stukken code hoef je niet over te typen. Je kunt ze natuurl
 
 ### Stap 0: installatie voorbereidde code
 Download the code van GitHub: [Löve 2D shooter code](https://github.com/coderdojonijmegen/love2d-shooter/archive/master.zip)
-De zip-file bevat een `src/` folder. Kopieer de inhoud daarvan naar `c:\games\shooter`
-Om de voorbereidde code uit te voeren, druk je op de Windows knop en typ je 'cmd'. Je krijgt dan een zwart venster. 
+De zip-file bevat een `src/` folder. Kopieer de inhoud daarvan naar `c:\games\shooter`.
+Om de voorbereidde code uit te voeren, druk je op de Windows knop en typ je `cmd`. Je krijgt dan een zwart venster. 
 Typ dan cd `c:\games\shooter` om naar de folder te gaan waar je de code hebt neergezet. Typ tenslotte `c:\love\love.exe .\`
  om het programma te starten. Als alles goed gaat, krijg je een zwart venster.
 

--- a/index.md
+++ b/index.md
@@ -191,9 +191,9 @@ In Scratch zou dit er ongeveer als volgt hebben uitgezien:
       herhaal
       als &lt;toets [pijltje links v] ingedrukt?&gt; dan
 	  verander x met (-1)
+	  end
       als &lt;toets [pijltje rechts v] ingedrukt?&gt; dan
 	  verander x met (1)
-      end
 	  end
 	  end
 {{< /scratch >}}
@@ -463,12 +463,6 @@ Voeg daarvoor de volgende code toe aan functie `love.update(dt)`:
 
 <!--![Scratch spel is afgelopen](images/image2.png)-->
 
-{{< scratch >}}
-	  als &lt;raak ik [Vijand v]?&gt; dan
-	  maak[spelIsAfgelopen v] (1)
-	  end
-{{< /scratch >}}
-
 {{< highlight lua >}}
 -- als de speler een vijand geraakt heeft
 if spelerHeeftVijandGeraakt() then
@@ -478,6 +472,15 @@ if spelerHeeftVijandGeraakt() then
 
 end
 {{< /highlight >}}
+
+In Scratch zou het er zo uitzien:
+
+{{< scratch >}}
+	  als &lt;raak ik [Vijand v]?&gt; dan
+	  maak[spelIsAfgelopen v] (1)
+	  end
+{{< /scratch >}}
+
 			
 In variabele `spelIsAfgelopen` wordt bijgehouden of het spel nog loopt of al is afgelopen. Als het is afgelopen, 
 wordt de speler niet langer getekend. Pas daarvoor de functie `love.draw(dt)` aan door het tekenen van de speler 
@@ -553,13 +556,13 @@ In de `love.update(dt)` functie voeg je het volgende toe:
 {{< highlight lua >}}
 if spelIsAfgelopen == false then
 
--- als de spatiebalk wordt ingedrukt
-if love.keyboard.isDown('space') then
+	-- als de spatiebalk wordt ingedrukt
+	if love.keyboard.isDown('space') then
 
-  -- schiet dan
-  maakNieuweKogel(kogels, speler)
+	  -- schiet dan
+	  maakNieuweKogel(kogels, speler)
 
-end
+	end
 
 	maakNieuweVijand(vijanden)  
 {{< /highlight >}}
@@ -658,11 +661,11 @@ Daarvoor gaan we code toevoegen aan `love.update(dt)`:
 -- als de o van opnieuw wordt ingedrukt
 if love.keyboard.isDown('o') then
 
--- wordt het spel opnieuw gestart
-kogels = {}
-vijanden = {}
-score = 0
-spelIsAfgelopen = false
+	-- wordt het spel opnieuw gestart
+	kogels = {}
+	vijanden = {}
+	score = 0
+	spelIsAfgelopen = false
 
 end
 {{< /highlight >}}

--- a/src/conf.lua
+++ b/src/conf.lua
@@ -1,8 +1,7 @@
 -- Configuratie
 function love.conf(t)
-	t.title = "Shooter"		-- De titel van de game
-	t.version = "11.1"		-- De L�ve versie waarvoor deze game gemaakt is
-	t.window.width = 480	-- Breedte van de window waarin de game speelt
-	t.window.height = 650	-- Hoogte van de window waarin de game speelt
-
+   t.title = "Shooter"		-- De titel van de game
+   t.version = "11.1"		-- De L�ve versie waarvoor deze game gemaakt is
+   t.window.width = 480	-- Breedte van de window waarin de game speelt
+   t.window.height = 650	-- Hoogte van de window waarin de game speelt
 end

--- a/src/functies.lua
+++ b/src/functies.lua
@@ -38,7 +38,7 @@ nieuweKogelInterval = 20
 nieuweKogelTimer = 0
 function maakNieuweKogel(kogels, speler)
   if nieuweKogelTimer < 0 then
-    nieuweKogel = { x = speler.x + (speler.plaatje:getWidth()/2), y = spelerY, plaatje = kogelPlaatje }
+    nieuweKogel = { x = speler.x + (speler.plaatje:getWidth()/2), y = speler.y, plaatje = kogelPlaatje }
     table.insert(kogels, nieuweKogel)
     nieuweKogelTimer = nieuweKogelInterval
   else

--- a/src/voorbeeld.lua
+++ b/src/voorbeeld.lua
@@ -1,14 +1,14 @@
 require 'functies'
 
+-- de stapgrootte van de kogels
 stapGrootte = 2
-spelerY = 560
-spelerX = 200
-
+-- bepaalt of het spel afgelopen is
 spelIsAfgelopen = false
+-- de score van de speler
 score = 0
 
 -- variabelen om eigenschappen van de speler in op te slaan
-speler = { x = spelerX, y = spelerY, plaatje = nil }
+speler = { x = 200, y = 560, plaatje = nil }
 -- lijst om vijanden in op te slaan
 vijanden = {}
 -- lijst om kogels in op te slaan
@@ -46,77 +46,113 @@ end
 
 function love.update(dt)
 
+	-- als het spel niet is afgelopen, zorgen we dat het speelbaar is
+    if spelIsAfgelopen == false then
+		schietBijDrukOp('space')	
+		beweegKogels()
+        maakNieuweVijand(vijanden)  
+		beweegVijanden()
+		gameOverBijVijandAanraken()
+		puntenBijVijandRaken()
+		spelerBesturing()
+
+	-- als het spel wel is afgelopen, kijken we enkel of we opnieuw willen starten
+	else 
+		restartBijDrukOp('o')	
+	end
+end
+
+---------------------------------------------------------------------------
+-- Hier volgen alle functies die we in de functie love.update gebruiken. --
+---------------------------------------------------------------------------
+
+function restartBijDrukOp(toets)
+
     -- als de o van opnieuw wordt ingedrukt
-    if love.keyboard.isDown('o') then
+    if love.keyboard.isDown(toets) then
         -- wordt het spel opnieuw gestart
         kogels = {}
         vijanden = {}
         score = 0
         spelIsAfgelopen = false
     end
+end
 
-    if spelIsAfgelopen == false then
-        -- als de spatiebalk wordt ingedrukt
-        if love.keyboard.isDown('space') then
-            -- schiet dan
-            maakNieuweKogel(kogels, speler)
-        end
+function schietBijDrukOp(toets)
 
-        -- voor elke kogel in de lijst
-        for index, kogel in ipairs(kogels) do
+	-- als de spatiebalk wordt ingedrukt
+	if love.keyboard.isDown(toets) then
+		-- schiet dan
+		maakNieuweKogel(kogels, speler)
+	end
+end
 
-            -- beweeg de kogel naar boven
-            kogel.y = kogel.y - (2 * stapGrootte)
+function beweegKogels()
+	
+	-- voor elke kogel in de lijst
+	for index, kogel in ipairs(kogels) do
 
-            -- als de kogel de bovenrand heeft bereikt
-            if kogel.y < -20 then
-                -- verwijder het uit de lijst
-                table.remove(kogels, index)
-            end
-        end
+		-- beweeg de kogel naar boven
+		kogel.y = kogel.y - (2 * stapGrootte)
 
-        maakNieuweVijand(vijanden)  
+		-- als de kogel de bovenrand heeft bereikt
+		if kogel.y < -20 then
+			-- verwijder het uit de lijst
+			table.remove(kogels, index)
+		end
+	end
+end
 
-        -- voor elke vijand in de lijst  
-        for index, vijand in ipairs(vijanden) do
+function beweegVijanden()
 
-            -- laat de vijand een stapje naar beneden doen  
-            vijand.y = vijand.y + stapGrootte
+	-- voor elke vijand in de lijst  
+	for index, vijand in ipairs(vijanden) do
 
-            -- als de vijand de onderrand heeft bereikt
-            if vijand.y > yOnderRand() then
-                -- verwijder de vijand als ie buiten het venster is verdwenen
-                table.remove(vijanden, index)
-            end
-        end
+		-- laat de vijand een stapje naar beneden doen  
+		vijand.y = vijand.y + stapGrootte
 
-        -- als de speler een vijand geraakt heeft
-        if spelerHeeftVijandGeraakt() then
-            -- is het spel afgelopen
-            spelIsAfgelopen = true
-        end
+		-- als de vijand de onderrand heeft bereikt
+		if vijand.y > yOnderRand() then
+			-- verwijder de vijand als ie buiten het venster is verdwenen
+			table.remove(vijanden, index)
+		end
+	end
+end
 
-        -- als de kogel een vijand geraakt heeft
-        if kogelHeeftVijandGeraakt() then
-            -- heb je een punt gescoord
-            score = score + 1
-        end
+function gameOverBijVijandAanraken()
 
-        -- als pijltje naar links ingedrukt
-        if love.keyboard.isDown('left') then
-            -- en de linker rand is nog niet bereikt
-            if speler.x > 0 then
-                -- dan doe een stap naar links
-                speler.x = speler.x - stapGrootte
-            end
+		-- als de speler een vijand geraakt heeft
+	if spelerHeeftVijandGeraakt() then
+		-- is het spel afgelopen
+		spelIsAfgelopen = true
+	end
+end
 
-            -- als pijltje naar rechts ingedrukt
-        elseif love.keyboard.isDown('right') then
-            -- en de rechter rand is nog niet bereikt
-            if speler.x < xRechterRand() then
-                -- dan doe een stap naar rechts
-                speler.x = speler.x + stapGrootte
-            end
-        end
-    end
+function puntenBijVijandRaken()
+
+	-- als de kogel een vijand geraakt heeft
+	if kogelHeeftVijandGeraakt() then
+		-- heb je een punt gescoord
+		score = score + 1
+	end
+end
+
+function spelerBesturing()
+
+	-- als pijltje naar links ingedrukt
+	if love.keyboard.isDown('left') then
+		-- en de linker rand is nog niet bereikt
+		if speler.x > 0 then
+			-- dan doe een stap naar links
+			speler.x = speler.x - stapGrootte
+		end
+
+		-- als pijltje naar rechts ingedrukt
+	elseif love.keyboard.isDown('right') then
+		-- en de rechter rand is nog niet bereikt
+		if speler.x < xRechterRand() then
+			-- dan doe een stap naar rechts
+			speler.x = speler.x + stapGrootte
+		end
+	end
 end

--- a/src/voorbeeld.lua
+++ b/src/voorbeeld.lua
@@ -15,51 +15,51 @@ vijanden = {}
 kogels = {}
 
 function love.load(arg)
-    -- laadt het plaatje in eigenschap plaatje van de variabele speler
-    speler.plaatje = love.graphics.newImage('plaatjes/spelersVliegtuig.png')
-    -- laadt het plaatje van de vijand
-    vijandPlaatje = love.graphics.newImage('plaatjes/vijandsVliegtuig.png')
-    -- laadt het plaatje van de kogel
-    kogelPlaatje = love.graphics.newImage('plaatjes/kogel.png')
+   -- laad het plaatje in eigenschap plaatje van de variabele speler
+   speler.plaatje = love.graphics.newImage('plaatjes/spelersVliegtuig.png')
+   -- laad het plaatje van de vijand
+   vijandPlaatje = love.graphics.newImage('plaatjes/vijandsVliegtuig.png')
+   -- laad het plaatje van de kogel
+   kogelPlaatje = love.graphics.newImage('plaatjes/kogel.png')
 end
 
 function love.draw(dt)
-    -- als het spel nog niet is afgelopen
-    if spelIsAfgelopen == false then
-        -- teken het plaatje op het scherm
-        love.graphics.draw(speler.plaatje, speler.x, speler.y)
-        -- teken de vijanden in de lijst
-        tekenVijanden(vijanden)
-        -- teken de kogels in de lijst
-        tekenKogels(kogels)
-    else
-        love.graphics.print("game over", 200, 200)
-        love.graphics.print("typ 'o' om opnieuw te starten", 150, 250)
-    end
+   -- als het spel nog niet is afgelopen
+   if spelIsAfgelopen == false then
+      -- teken het plaatje op het scherm
+      love.graphics.draw(speler.plaatje, speler.x, speler.y)
+      -- teken de vijanden in de lijst
+      tekenVijanden(vijanden)
+      -- teken de kogels in de lijst
+      tekenKogels(kogels)
+   else
+      love.graphics.print("game over", 200, 200)
+      love.graphics.print("typ 'o' om opnieuw te starten", 150, 250)
+   end
 
-    -- zet de tekstkleur op wit
-    love.graphics.setColor(255, 255, 255)
-    -- en druk de score af
-    love.graphics.print("SCORE: " .. tostring(score), 400, 10)
+   -- zet de tekstkleur op wit
+   love.graphics.setColor(255, 255, 255)
+   -- en druk de score af
+   love.graphics.print("SCORE: " .. tostring(score), 400, 10)
 
 end
 
 function love.update(dt)
 
-	-- als het spel niet is afgelopen, zorgen we dat het speelbaar is
-    if spelIsAfgelopen == false then
-		schietBijDrukOp('space')	
-		beweegKogels()
-        maakNieuweVijand(vijanden)  
-		beweegVijanden()
-		gameOverBijVijandAanraken()
-		puntenBijVijandRaken()
-		spelerBesturing()
+   -- als het spel niet is afgelopen, zorgen we dat het speelbaar is
+   if spelIsAfgelopen == false then
+      schietBijDrukOp('space')
+      beweegKogels()
+      maakNieuweVijand(vijanden)
+      beweegVijanden()
+      gameOverBijVijandAanraken()
+      puntenBijVijandRaken()
+      spelerBesturing()
 
-	-- als het spel wel is afgelopen, kijken we enkel of we opnieuw willen starten
-	else 
-		restartBijDrukOp('o')	
-	end
+      -- als het spel wel is afgelopen, kijken we enkel of we opnieuw willen starten
+   else
+      restartBijDrukOp('o')
+   end
 end
 
 ---------------------------------------------------------------------------
@@ -68,91 +68,91 @@ end
 
 function restartBijDrukOp(toets)
 
-    -- als de o van opnieuw wordt ingedrukt
-    if love.keyboard.isDown(toets) then
-        -- wordt het spel opnieuw gestart
-        kogels = {}
-        vijanden = {}
-        score = 0
-        spelIsAfgelopen = false
-    end
+   -- als de o van opnieuw wordt ingedrukt
+   if love.keyboard.isDown(toets) then
+      -- wordt het spel opnieuw gestart
+      kogels = {}
+      vijanden = {}
+      score = 0
+      spelIsAfgelopen = false
+   end
 end
 
 function schietBijDrukOp(toets)
 
-	-- als de spatiebalk wordt ingedrukt
-	if love.keyboard.isDown(toets) then
-		-- schiet dan
-		maakNieuweKogel(kogels, speler)
-	end
+   -- als de spatiebalk wordt ingedrukt
+   if love.keyboard.isDown(toets) then
+      -- schiet dan
+      maakNieuweKogel(kogels, speler)
+   end
 end
 
 function beweegKogels()
-	
-	-- voor elke kogel in de lijst
-	for index, kogel in ipairs(kogels) do
 
-		-- beweeg de kogel naar boven
-		kogel.y = kogel.y - (2 * stapGrootte)
+   -- voor elke kogel in de lijst
+   for index, kogel in ipairs(kogels) do
 
-		-- als de kogel de bovenrand heeft bereikt
-		if kogel.y < -20 then
-			-- verwijder het uit de lijst
-			table.remove(kogels, index)
-		end
-	end
+      -- beweeg de kogel naar boven
+      kogel.y = kogel.y - (2 * stapGrootte)
+
+      -- als de kogel de bovenrand heeft bereikt
+      if kogel.y < -20 then
+         -- verwijder het uit de lijst
+         table.remove(kogels, index)
+      end
+   end
 end
 
 function beweegVijanden()
 
-	-- voor elke vijand in de lijst  
-	for index, vijand in ipairs(vijanden) do
+   -- voor elke vijand in de lijst
+   for index, vijand in ipairs(vijanden) do
 
-		-- laat de vijand een stapje naar beneden doen  
-		vijand.y = vijand.y + stapGrootte
+      -- laat de vijand een stapje naar beneden doen
+      vijand.y = vijand.y + stapGrootte
 
-		-- als de vijand de onderrand heeft bereikt
-		if vijand.y > yOnderRand() then
-			-- verwijder de vijand als ie buiten het venster is verdwenen
-			table.remove(vijanden, index)
-		end
-	end
+      -- als de vijand de onderrand heeft bereikt
+      if vijand.y > yOnderRand() then
+         -- verwijder de vijand als ie buiten het venster is verdwenen
+         table.remove(vijanden, index)
+      end
+   end
 end
 
 function gameOverBijVijandAanraken()
 
-		-- als de speler een vijand geraakt heeft
-	if spelerHeeftVijandGeraakt() then
-		-- is het spel afgelopen
-		spelIsAfgelopen = true
-	end
+   -- als de speler een vijand geraakt heeft
+   if spelerHeeftVijandGeraakt() then
+      -- is het spel afgelopen
+      spelIsAfgelopen = true
+   end
 end
 
 function puntenBijVijandRaken()
 
-	-- als de kogel een vijand geraakt heeft
-	if kogelHeeftVijandGeraakt() then
-		-- heb je een punt gescoord
-		score = score + 1
-	end
+   -- als de kogel een vijand geraakt heeft
+   if kogelHeeftVijandGeraakt() then
+      -- heb je een punt gescoord
+      score = score + 1
+   end
 end
 
 function spelerBesturing()
 
-	-- als pijltje naar links ingedrukt
-	if love.keyboard.isDown('left') then
-		-- en de linker rand is nog niet bereikt
-		if speler.x > 0 then
-			-- dan doe een stap naar links
-			speler.x = speler.x - stapGrootte
-		end
+   -- als pijltje naar links ingedrukt
+   if love.keyboard.isDown('left') then
+      -- en de linker rand is nog niet bereikt
+      if speler.x > 0 then
+         -- dan doe een stap naar links
+         speler.x = speler.x - stapGrootte
+      end
 
-		-- als pijltje naar rechts ingedrukt
-	elseif love.keyboard.isDown('right') then
-		-- en de rechter rand is nog niet bereikt
-		if speler.x < xRechterRand() then
-			-- dan doe een stap naar rechts
-			speler.x = speler.x + stapGrootte
-		end
-	end
+      -- als pijltje naar rechts ingedrukt
+   elseif love.keyboard.isDown('right') then
+      -- en de rechter rand is nog niet bereikt
+      if speler.x < xRechterRand() then
+         -- dan doe een stap naar rechts
+         speler.x = speler.x + stapGrootte
+      end
+   end
 end

--- a/src/voorbeeld.lua
+++ b/src/voorbeeld.lua
@@ -58,6 +58,7 @@ function love.update(dt)
 
       -- als het spel wel is afgelopen, kijken we enkel of we opnieuw willen starten
    else
+      -- de 'o' van opnieuw
       restartBijDrukOp('o')
    end
 end
@@ -68,7 +69,7 @@ end
 
 function restartBijDrukOp(toets)
 
-   -- als de o van opnieuw wordt ingedrukt
+   -- als toets wordt ingedrukt
    if love.keyboard.isDown(toets) then
       -- wordt het spel opnieuw gestart
       kogels = {}
@@ -80,7 +81,7 @@ end
 
 function schietBijDrukOp(toets)
 
-   -- als de spatiebalk wordt ingedrukt
+   -- als toets wordt ingedrukt
    if love.keyboard.isDown(toets) then
       -- schiet dan
       maakNieuweKogel(kogels, speler)


### PR DESCRIPTION
Scratch voorbeelden update. Afbeeldingen voor zekerheid behouden.
Fix src/functies zodat je geen spelerX/spelerY nodig hebt (staat niet in instructie)
Refactor voorbeeld voor leesbaarheid.
Taalgebruik hier en daar iets veranderd.

Evt zou de instructie nog naar de functie opzet vd voorbeeldcode kunnen worden aangepast.